### PR TITLE
fix: make opencv dependency optional to prevent conflicts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,6 @@ dependencies = [
     "ipdb>=0.13.13",
     "joblib>=1.4.2",
     "mediapipe>=0.10.0",
-    "opencv-python<4.10",
     "pytorch-lightning==1.5.0",
     "setuptools>=75.2.0",
     "tabulate>=0.9.0",
@@ -34,6 +33,12 @@ dependencies = [
     "ultralytics>=8.3.23",
     "yacs>=0.1.8",
 ]
+
+[project.optional-dependencies]
+# OpenCV variants - install ONE of these (or none if already installed)
+opencv = ["opencv-python>=4.0.0"]
+opencv-headless = ["opencv-python-headless>=4.0.0"]
+opencv-contrib = ["opencv-contrib-python>=4.0.0"]
 
 [tool.uv.sources]
 chumpy = { git = "https://github.com/IntelligentSensingAndRehabilitation/chumpy" }


### PR DESCRIPTION
- Remove opencv-python<4.10 from hard dependencies
- Add opencv variants as optional-dependencies
- This prevents conflicts when multiple packages require different opencv variants

🤖 Generated with [Claude Code](https://claude.com/claude-code)